### PR TITLE
Improve error handling for contact form

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,9 @@
 # For local development - use root path
 VITE_BASE=/
 
+# Supabase configuration
+VITE_SUPABASE_URL=https://kinmyuasdizgccihapsg.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY
+
 # For GitHub Pages deployment, uncomment the line below instead:
 # VITE_BASE=/website/

--- a/.env.production
+++ b/.env.production
@@ -2,5 +2,9 @@
 # For GitHub Pages deployment
 VITE_BASE=/website/
 
+# Supabase configuration for production
+VITE_SUPABASE_URL=https://kinmyuasdizgccihapsg.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY
+
 # When switching to root domain, change to:
 # VITE_BASE=/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The website connects to Supabase to store:
 
 The database is configured with proper Row Level Security (RLS) policies to allow public form submissions while restricting data access to authenticated administrators.
 
+Environment variables `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are used
+to configure the Supabase client. Example values are provided in `.env` and
+`.env.production`.
+
 ## Environment
 
 - Node.js 18+

--- a/src/components/ContactUs.tsx
+++ b/src/components/ContactUs.tsx
@@ -45,8 +45,9 @@ const ContactUs = () => {
       setIsSubmitted(true);
       setFormData({ firstName: "", lastName: "", email: "", phone: "", message: "" });
       setTimeout(() => setIsSubmitted(false), 5000);
-    } catch (err) {
-      setError("Failed to send message. Please try again.");
+    } catch (err: any) {
+      const message = err?.message || "Failed to send message. Please try again.";
+      setError(message);
       console.error("Contact form error:", err);
     } finally {
       setIsSubmitting(false);
@@ -63,8 +64,11 @@ const ContactUs = () => {
       setIsNewsletterSubmitted(true);
       setNewsletterEmail("");
       setTimeout(() => setIsNewsletterSubmitted(false), 5000);
-    } catch (err) {
-      setNewsletterError("Failed to subscribe. Please try again.");
+    } catch (err: any) {
+      const message = err?.code === "23505"
+        ? "You are already subscribed with this email address."
+        : err?.message || "Failed to subscribe. Please try again.";
+      setNewsletterError(message);
       console.error("Newsletter signup error:", err);
     } finally {
       setIsNewsletterSubmitting(false);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://kinmyuasdizgccihapsg.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY";
+const SUPABASE_URL =
+  import.meta.env.VITE_SUPABASE_URL ||
+  "https://kinmyuasdizgccihapsg.supabase.co";
+const SUPABASE_PUBLISHABLE_KEY =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY";
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,12 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = "https://kinmyuasdizgccihapsg.supabase.co";
-const supabaseAnonKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY";
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ||
+  'https://kinmyuasdizgccihapsg.supabase.co';
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpbm15dWFzZGl6Z2NjaWhhcHNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxODU2OTIsImV4cCI6MjA2NTc2MTY5Mn0.H0xsQ7V0UEMvsYp_rErKZN0SEKP6dhivCQF-bzTgjKY';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Summary
- improve error messages for contact and newsletter forms to surface Supabase errors
- load Supabase credentials from `.env` files so GitHub Pages can inject secrets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686441d404148324b2eaec7fa26cfca8