### PR TITLE
Add Google Tag Manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WD7H489G');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hikaflow - Your On-Demand AI Engineer for Confident Releases</title>
@@ -31,6 +38,10 @@
   </head>
 
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD7H489G"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="text/javascript">
       // GitHub Pages SPA redirect handling


### PR DESCRIPTION
## Summary
- add Google Tag Manager snippet in head
- add noscript fallback in body

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c21e34108324a7ba921e97ece50e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Google Tag Manager (GTM-WD7H489G) to enable analytics and tag management across the site. Injects the GTM loader in the head and a noscript iframe fallback in the body for users with JavaScript disabled.

<!-- End of auto-generated description by cubic. -->

