### PR TITLE
Add Twitter conversion tracking script

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,15 @@
       gtag('js', new Date());
       gtag('config', 'G-4FZ9Z5E7JQ', { send_page_view: false });
     </script>
+    <!-- Twitter conversion tracking base code -->
+    <script>
+      !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+      },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+      a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+      twq('config','qfvnm');
+    </script>
+    <!-- End Twitter conversion tracking base code -->
+
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- integrate Twitter conversion tracking script before closing head tag

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b8a28f24f08324b62bbc99643efb58
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Twitter conversion tracking to index.html. Loads the UWT script in the head and initializes with pixel ID qfvnm to track conversions from Twitter ads.

<!-- End of auto-generated description by cubic. -->

